### PR TITLE
Add pycodestyle linting setup

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/PyCQA/pycodestyle
+    rev: v2.11.0
+    hooks:
+      - id: pycodestyle
+        args: [app.py]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+lint:
+	pycodestyle app.py

--- a/README.md
+++ b/README.md
@@ -1,0 +1,26 @@
+# My First Repo
+
+This repository contains a Streamlit app for analyzing Apple Health data.
+
+## Linting
+
+To check code style with PEP8 using `pycodestyle`, run:
+
+```bash
+make lint
+```
+
+If you use npm-based workflow, run:
+
+```bash
+npm run lint
+```
+
+## Pre-commit
+
+Install pre-commit hooks to run linting automatically before each commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas
 lxml
 scipy
 plotly
+
+pycodestyle


### PR DESCRIPTION
## Summary
- add pycodestyle to requirements
- provide a Makefile with a `lint` command
- document linting and pre-commit usage
- configure pre-commit to run pycodestyle

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_685128b36a2c8323b9e465286c2fec7a