### PR TITLE
Refactor analysis code into modules

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,6 @@
+repos:
+  - repo: https://github.com/PyCQA/pycodestyle
+    rev: v2.11.0
+    hooks:
+      - id: pycodestyle
+        args: [app.py, parser.py, analysis.py]

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,2 +1,4 @@
 [server]
 runOnSave = true
+maxUploadSize = 1024
+maxMessageSize = 1024

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,2 @@
+lint:
+	pycodestyle app.py parser.py analysis.py

--- a/README.md
+++ b/README.md
@@ -1,0 +1,27 @@
+# My First Repo
+
+This repository contains a Streamlit app for analyzing Apple Health data.
+The application is configured to accept XML exports up to **1 GB**.
+
+## Linting
+
+To check code style with PEP8 using `pycodestyle`, run:
+
+```bash
+make lint
+```
+
+If you use npm-based workflow, run:
+
+```bash
+npm run lint
+```
+
+## Pre-commit
+
+Install pre-commit hooks to run linting automatically before each commit:
+
+```bash
+pip install pre-commit
+pre-commit install
+```

--- a/analysis.py
+++ b/analysis.py
@@ -1,0 +1,67 @@
+import pandas as pd
+import scipy.stats as ss
+from itertools import combinations
+
+
+def prepare_table(df, period):
+    """Aggregate records by selected period."""
+    if period == 'Неделя':
+        df['period'] = df['date'] - pd.to_timedelta(df['date'].dt.weekday, unit='D')
+    elif period == 'Месяц':
+        df['period'] = df['date'].values.astype('datetime64[M]')
+    else:
+        df['period'] = df['date']
+
+    mean_pattern = 'SleepAnalysis|Weight|BMI|Variability|HRV'
+    metric_means = df[df['metric'].str.contains(mean_pattern)]
+    metric_sums = df[~df['metric'].str.contains(mean_pattern)]
+
+    pt_sum = metric_sums.pivot_table(index='period', columns='metric', values='value', aggfunc='sum')
+    pt_mean = metric_means.pivot_table(index='period', columns='metric', values='value', aggfunc='mean')
+    return pd.concat([pt_sum, pt_mean], axis=1).sort_index()
+
+
+def analyze_pairs(wide_df, p_thr, min_N):
+    """Return DataFrame with significant correlations."""
+    results = []
+    pairs = combinations(wide_df.columns.dropna(), 2)
+    for X, Y in pairs:
+        series = wide_df[[X, Y]].dropna()
+        N = len(series)
+        if N < min_N:
+            continue
+        if series[X].nunique() < 2 or series[Y].nunique() < 2:
+            continue
+        try:
+            res = ss.linregress(series[X], series[Y])
+        except ValueError:
+            continue
+        if res.pvalue > p_thr:
+            continue
+        results.append({'X_raw': X, 'Y_raw': Y, 'r': res.rvalue, 'p': res.pvalue, 'N': N})
+    return pd.DataFrame(results).sort_values('p')
+
+
+def compute_delta_optx(wide_df, pairs_df):
+    """Calculate ΔY and optimal X for each pair."""
+    delta_list = []
+    optx_list = []
+    for _, row in pairs_df.iterrows():
+        X = row['X_raw']
+        Y = row['Y_raw']
+        series = wide_df[[X, Y]].dropna()
+        dy = series[Y].diff().dropna().mean()
+        delta_list.append(dy)
+        thresh = 0.95 * series[Y].max()
+        xs = series[X][series[Y] >= thresh]
+        optx_list.append(xs.min() if not xs.empty else None)
+    pairs_df['ΔY'] = delta_list
+    pairs_df['OptX'] = optx_list
+    return pairs_df
+
+
+def pretty(name):
+    base = name
+    base = base.replace('HKCategoryTypeIdentifier', '')
+    base = base.replace('HKQuantityTypeIdentifier', '')
+    return ''.join([' ' + c if c.isupper() else c for c in base]).strip()

--- a/parser.py
+++ b/parser.py
@@ -1,0 +1,53 @@
+import streamlit as st
+import io
+from io import BytesIO
+from lxml import etree
+from datetime import datetime
+import pandas as pd
+
+
+def load_data(file_bytes):
+    """Parse Apple Health XML bytes into DataFrame."""
+    records = []
+    for _, elem in etree.iterparse(BytesIO(file_bytes), tag='Record'):
+        record_type = elem.get('type')
+        start = elem.get('startDate')
+        if not record_type or not start:
+            elem.clear()
+            continue
+        date = datetime.fromisoformat(start).date()
+        if record_type.endswith('SleepAnalysis'):
+            if elem.get('value') != 'HKCategoryValueSleepAnalysisAsleepDeep':
+                elem.clear()
+                continue
+            duration = (
+                datetime.fromisoformat(elem.get('endDate'))
+                - datetime.fromisoformat(start)
+            ).total_seconds() / 60
+            records.append({'date': date, 'metric': record_type, 'value': duration})
+            dt_start = datetime.fromisoformat(start)
+            bedtime_val = dt_start.hour * 60 + dt_start.minute
+            records.append({'date': dt_start.date(), 'metric': 'Bedtime', 'value': bedtime_val})
+            dt_end = datetime.fromisoformat(elem.get('endDate'))
+            wake_val = dt_end.hour * 60 + dt_end.minute
+            records.append({'date': dt_end.date(), 'metric': 'WakeTime', 'value': wake_val})
+        else:
+            try:
+                val = float(elem.get('value') or 0)
+            except ValueError:
+                val = 0
+            records.append({'date': date, 'metric': record_type, 'value': val})
+        elem.clear()
+    return pd.DataFrame(records)
+
+
+@st.cache_data(show_spinner=False)
+def get_types(file_bytes):
+    """Return sorted list of unique Record types."""
+    types = set()
+    for _, elem in etree.iterparse(BytesIO(file_bytes), tag='Record'):
+        record_type = elem.get('type')
+        if record_type:
+            types.add(record_type)
+        elem.clear()
+    return sorted(types)

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,5 @@ pandas
 lxml
 scipy
 plotly
+
+pycodestyle


### PR DESCRIPTION
## Summary
- split parsing and analysis logic into `parser.py` and `analysis.py`
- remove unused imports and simplify `app.py`
- compute min_N and group filters vectorially
- update lint targets and pre‑commit config
- increase XML upload limit to 1GB

## Testing
- `make lint` *(fails: pycodestyle not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685128b36a2c8323b9e465286c2fec7a